### PR TITLE
github actionsの追加

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,17 @@
+name: Middleman
+
+on:
+  push:
+    branches: [master, feature/gh-action]
+
+jobs:
+  build_and_deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build & Deploy to GitHub Pages
+        with:
+          REMOTE_BRANCH: gh-pages
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: yurikoval/middleman-gh-pages-action@master

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,7 @@ name: Middleman
 
 on:
   push:
-    branches: [main, feature/gh-action]
+    branches: [main, introduce_middleman]
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,7 @@ name: Middleman
 
 on:
   push:
-    branches: [master, feature/gh-action]
+    branches: [main, feature/gh-action]
 
 jobs:
   build_and_deploy:
@@ -14,4 +14,4 @@ jobs:
         with:
           REMOTE_BRANCH: gh-pages
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: yurikoval/middleman-gh-pages-action@master
+        uses: keebkaigi/middleman-gh-pages-action@master

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,10 +8,11 @@ jobs:
   build_and_deploy:
     name: Build & Deploy
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: actions/checkout@v1
       - name: Build & Deploy to GitHub Pages
         with:
           REMOTE_BRANCH: gh-pages
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: keebkaigi/middleman-gh-pages-action@master
+        uses: yurikoval/middleman-gh-pages-action@master


### PR DESCRIPTION
github actions 追加しておきました。

`main`と`introduce_middleman`ブランチにPushすると`gh-pages`ブランチにビルドされたものが配置されます。
現状はmainブランチが公開されていますが、いい感じのタイミングでgh-pagesに変えればOK。

settings > pages > Branch

![image](https://user-images.githubusercontent.com/6962187/226537697-8fb7c808-53e3-4d81-b5fe-4aca961e3082.png)
