### PR TITLE
Fix Monstarlab logo width

### DIFF
--- a/source/stylesheets/site.css.sass
+++ b/source/stylesheets/site.css.sass
@@ -235,9 +235,6 @@ a
 .sponsor__main-logo-image
   width: 20rem
 
-  @media (max-width: 400px)
-    width: 100%
-
 .sponsor__sub-list
   list-style: none
   padding: 0


### PR DESCRIPTION
- ロゴの表示幅がおかしいのを修正
- サイトでは HTML のみ更新されてて、CSSは古いままになっており、スーパーリロードしても更新されなくて謎でした…
    - gh-pages ブランチの build には新しいCSSが反映されていました
    - とりあえず、該当部分の Sassを微妙に書き直して更新されるかどうかやってみます〜