### PR TITLE
teaser textから場所や時間の予告を削る

### DIFF
--- a/data/year_2023/teaser.yml
+++ b/data/year_2023/teaser.yml
@@ -1,13 +1,9 @@
 message:
   en: |
-    It will be held in Matsumoto, Nagano sometime in the late afternoon on May 10th.
-    <br />
     Details are coming soon, but we can tell you one thing for sure -- you will need to register in advance to join.
     <br />
     Make sure to save the date and arrange your travel plans to Matsumoto if you are interested.
   ja: |
-    5月10日の午後ちょい遅めぐらいから松本で開催します
-    <br />
     詳細は追ってお知らせする予定ですが、事前に参加登録が必要となります
     <br />
     興味のある方は、ご自身の予定の確認と、松本行きの旅程を調整しておいてください


### PR DESCRIPTION
#13 で時間帯と場所をアナウンスしたので不要になった。

