### PR TITLE
ふきだしをテキスト内容に合わせて伸縮可能にする

### DIFF
--- a/source/stylesheets/site.css.sass
+++ b/source/stylesheets/site.css.sass
@@ -339,7 +339,7 @@ a
     border-right: $size solid transparent
     bottom: -1 * $size * 2
     left: $left
-    transform: translateX(-0.5rem)
+    transform: translate(-0.5rem, -1px)
 
 .hero__registration-description-text
 

--- a/source/stylesheets/site.css.sass
+++ b/source/stylesheets/site.css.sass
@@ -316,8 +316,10 @@ a
 .hero__registration-description
   font-size: 0.9rem
   margin: 0 auto 1.5rem
-  width: 9rem
+  display: inline-block
+  width: auto
   height: 2rem
+  padding: 0 1rem
   border-radius: 2rem
   background-color: $text-color
   color: $bg-color
@@ -326,7 +328,7 @@ a
   animation: bounce 1s ease-in-out infinite
   &:after
     $size: 0.5rem
-    $left: 4.5rem
+    $left: 50%
     $color: $text-color
     position: absolute
     content: ""


### PR DESCRIPTION
最初からこう作っておけばよかったです…… :pray:
以降、ﾌｷﾀﾞｼの中の内容は幅を気にせず変えることができると思います〜 >@kakautani

<img width="458" alt="image" src="https://user-images.githubusercontent.com/341101/229665887-7ec7eef7-c7a7-4b31-9e7f-63d48211b8d6.png">

<img width="498" alt="image" src="https://user-images.githubusercontent.com/341101/229665962-30a4a08c-ec4a-4e3d-9e54-76fedc3357d7.png">

<img width="519" alt="image" src="https://user-images.githubusercontent.com/341101/229666058-19c34159-2074-4066-a28d-b498a2473a5c.png">
