### PR TITLE
Avoid use yaml with html because of rendering error of production

### DIFF
--- a/source/2023.html.haml
+++ b/source/2023.html.haml
@@ -66,25 +66,7 @@ keywords: keyboard, DIY keyboard, RubyKaigi, 自作キーボード, keeb, keebka
           .hero__registration-description-icon
             %i.fa-solid.fa-arrow-turn-down-left
           %span.hero__text= 'ENTER'
-      .hero__live
-        %h3.hero__live-heading
-          = d.general.live_streaming.heading
-        .hero__live-streamer
-          .hero__live-streamer-by by
-          = link_to d.general.live_streaming.streamer.youtube, class: 'hero__live-streamer-link', target: '_blank' do
-            .hero__live-streamer-avatar
-              = image_tag d.general.live_streaming.streamer.avatar,
-                class: 'hero__live-streamer-avatar-image',
-                alt: d.general.live_streaming.streamer.name
-            .hero__live-streamer-right
-              .hero__live-streamer-name
-                = d.general.live_streaming.streamer.name
-            = link_to d.general.live_streaming.streamer.twitter,
-              class: 'hero__live-streamer-twitter-link',
-              target: '_blank' do
-              = "@#{d.general.live_streaming.streamer.id}"
-        %p.hero__live-text
-          = d.general.live_streaming.message_ja_html
+      = partial('partials/live_notice')
 
   = partial('partials/schedule')
   = partial('partials/twitter')

--- a/source/partials/_live_notice.html.haml
+++ b/source/partials/_live_notice.html.haml
@@ -1,0 +1,23 @@
+.hero__live
+  %h3.hero__live-heading
+    = data.year_2023.general.live_streaming.heading
+  .hero__live-streamer
+    .hero__live-streamer-by by
+    = link_to data.year_2023.general.live_streaming.streamer.youtube, class: 'hero__live-streamer-link', target: '_blank' do
+      .hero__live-streamer-avatar
+        = image_tag data.year_2023.general.live_streaming.streamer.avatar,
+          class: 'hero__live-streamer-avatar-image',
+          alt: data.year_2023.general.live_streaming.streamer.name
+      .hero__live-streamer-right
+        .hero__live-streamer-name
+          = data.year_2023.general.live_streaming.streamer.name
+      = link_to data.year_2023.general.live_streaming.streamer.twitter,
+        class: 'hero__live-streamer-twitter-link',
+        target: '_blank' do
+        = "@#{data.year_2023.general.live_streaming.streamer.id}"
+  %p.hero__live-text
+    = '当日はキーボード動画でおなじみの'
+    = link_to 'Daihuku Keyboard さんのチャンネル', 'https://www.youtube.com/c/daihukukeyboard', target: '_blank'
+    = 'からオンライン配信予定です。'
+    %br
+    = '現地参加できない方も YouTube 配信をお楽しみに！'


### PR DESCRIPTION
#52 53 の対策をもってしても、依然スクショ部分の表示崩れが直らないので、以下を試しています

- 該当部分の yaml データの html 化が、なぜか本番だけでうまくいっていない可能性があるので、該当部分の yaml 化を諦めて、haml に直書きしてみる
- （ついでに）おそらくこの部分は当日に変更か差し替えがありそうなので、前もって partial 化しておく 

<img width="1463" alt="image" src="https://user-images.githubusercontent.com/341101/236465257-c6025878-33aa-477b-a3cd-04d0a5e1bf65.png">

💭 直ってほしい……