### PR TITLE
 当日ライブストリーミング画面を貼る？

### DIFF
--- a/data/year_2023/live.yml
+++ b/data/year_2023/live.yml
@@ -1,0 +1,3 @@
+title: Live Streaming
+url: https://www.youtube.com/watch?v=QdIn2UtSPfs&ab_channel=DaihukuKeyboard #要差し替え
+embed_src: https://www.youtube.com/embed/QdIn2UtSPfs #要差し替え

--- a/data/year_2023/live.yml
+++ b/data/year_2023/live.yml
@@ -1,3 +1,3 @@
 title: Live Streaming
-url: https://www.youtube.com/watch?v=QdIn2UtSPfs&ab_channel=DaihukuKeyboard #要差し替え
-embed_src: https://www.youtube.com/embed/QdIn2UtSPfs #要差し替え
+url: https://youtube.com/live/Hg66nYmoFhQ?feature=share #要差し替え
+embed_src: https://www.youtube.com/embed/Hg66nYmoFhQ #要差し替え

--- a/source/2023.html.haml
+++ b/source/2023.html.haml
@@ -64,7 +64,7 @@ keywords: keyboard, DIY keyboard, RubyKaigi, 自作キーボード, keeb, keebka
           class: 'registration__button',
           target: '_blank' do
           %span.registration__text= 'Registration Closed'
-      = partial('partials/live_notice')
+      -# = partial('partials/live_notice')
 
   = partial('partials/schedule')
   = partial('partials/note')

--- a/source/2023.html.haml
+++ b/source/2023.html.haml
@@ -66,6 +66,7 @@ keywords: keyboard, DIY keyboard, RubyKaigi, 自作キーボード, keeb, keebka
           %span.registration__text= 'Registration Closed'
       -# = partial('partials/live_notice')
 
+  = partial('partials/live')
   = partial('partials/schedule')
   = partial('partials/note')
   = partial('partials/drink_up')

--- a/source/partials/_live.html.haml
+++ b/source/partials/_live.html.haml
@@ -13,4 +13,4 @@
   %p.hero__live-text
     = 'キーボード動画でおなじみの'
     = link_to 'Daihuku Keyboard さんのチャンネル', 'https://www.youtube.com/c/daihukukeyboard', target: '_blank'
-    = 'からオンライン配信中です！'
+    = 'からオンライン配信します！'

--- a/source/partials/_live.html.haml
+++ b/source/partials/_live.html.haml
@@ -1,0 +1,16 @@
+%section.live#live
+  %h2.h2
+    = link_to data.year_2023.live.url, target: '_blank' do
+      = data.year_2023.live.title
+  .live__screen
+    %iframe{:allow => "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share",
+      :allowfullscreen => "",
+      :frameborder => "0",
+      :height => "315",
+      :src => data.year_2023.live.embed_src,
+      :title => "YouTube video player", :width => "560"}
+  = partial ('partials/live_streamer')
+  %p.hero__live-text
+    = 'キーボード動画でおなじみの'
+    = link_to 'Daihuku Keyboard さんのチャンネル', 'https://www.youtube.com/c/daihukukeyboard', target: '_blank'
+    = 'からオンライン配信中です！'

--- a/source/partials/_live_notice.html.haml
+++ b/source/partials/_live_notice.html.haml
@@ -1,20 +1,7 @@
 .hero__live
   %h3.hero__live-heading
     = data.year_2023.general.live_streaming.heading
-  .hero__live-streamer
-    .hero__live-streamer-by by
-    = link_to data.year_2023.general.live_streaming.streamer.youtube, class: 'hero__live-streamer-link', target: '_blank' do
-      .hero__live-streamer-avatar
-        = image_tag "avatars/#{data.year_2023.general.live_streaming.streamer.avatar}",
-          class: 'hero__live-streamer-avatar-image',
-          alt: data.year_2023.general.live_streaming.streamer.name
-      .hero__live-streamer-right
-        .hero__live-streamer-name
-          = data.year_2023.general.live_streaming.streamer.name
-      = link_to data.year_2023.general.live_streaming.streamer.twitter,
-        class: 'hero__live-streamer-twitter-link',
-        target: '_blank' do
-        = "@#{data.year_2023.general.live_streaming.streamer.id}"
+  = partial ('partials/live_streamer')
   %p.hero__live-text
     = '当日はキーボード動画でおなじみの'
     = link_to 'Daihuku Keyboard さんのチャンネル', 'https://www.youtube.com/c/daihukukeyboard', target: '_blank'

--- a/source/partials/_live_streamer.html.haml
+++ b/source/partials/_live_streamer.html.haml
@@ -1,0 +1,14 @@
+.live-streamer
+  .live-streamer__by by
+  = link_to data.year_2023.general.live_streaming.streamer.youtube, class: 'live-streamer__link', target: '_blank' do
+    .live-streamer__avatar
+      = image_tag "avatars/#{data.year_2023.general.live_streaming.streamer.avatar}",
+        class: 'live-streamer__avatar-image',
+        alt: data.year_2023.general.live_streaming.streamer.name
+    .live-streamer__right
+      .live-streamer__name
+        = data.year_2023.general.live_streaming.streamer.name
+    = link_to data.year_2023.general.live_streaming.streamer.twitter,
+      class: 'live-streamer__twitter-link',
+      target: '_blank' do
+      = "@#{data.year_2023.general.live_streaming.streamer.id}"

--- a/source/stylesheets/_hero.css.sass
+++ b/source/stylesheets/_hero.css.sass
@@ -194,20 +194,20 @@
   align-items: center
   font-size: 1.2rem
 
-.hero__live-streamer-link
+.live-streamer__link
   display: flex
   flex-wrap: wrap
   align-items: center
   margin-right: 1rem
 
   &:hover
-    .hero__live-streamer-avatar
+    .live-streamer__avatar
       animation: gaming-diagonal 0.3s linear infinite
 
-.hero__live-streamer-by
+.live-streamer__by
   margin-right: 0.6rem
 
-.hero__live-streamer-avatar
+.live-streamer__avatar
   height: $avatar-small
   width: $avatar-small
   position: relative
@@ -218,7 +218,7 @@
   border-radius: 8px
   animation: gaming-diagonal 6s linear infinite
 
-.hero__live-streamer-avatar-image
+.live-streamer__avatar-image
   height: $avatar-small - 6px
   width: $avatar-small - 6px
   position: absolute
@@ -226,7 +226,7 @@
   top: 3px
   left: 3px
 
-.hero__live-streamer-twitter-link
+.live-streamer__twitter-link
   font-weight: 400
   font-size: 1rem
 

--- a/source/stylesheets/_live-streamer.css.sass
+++ b/source/stylesheets/_live-streamer.css.sass
@@ -1,0 +1,45 @@
+// .live-streamer
+
+.live-streamer
+  display: flex
+  flex-wrap: wrap
+  margin: 0 auto
+  justify-content: center
+  align-items: center
+  font-size: 1.2rem
+
+.live-streamer__link
+  display: flex
+  flex-wrap: wrap
+  align-items: center
+  margin-right: 1rem
+
+  &:hover
+    .live-streamer__avatar
+      animation: gaming-diagonal 0.3s linear infinite
+
+.live-streamer__by
+  margin-right: 0.6rem
+
+.live-streamer__avatar
+  height: $avatar-small
+  width: $avatar-small
+  position: relative
+  flex: 0 0 $avatar-small
+  margin-right: 0.6rem
+  background: linear-gradient(45deg, #39B54A 0%, #FCC02E 25%, #f25350 50%, #F92174 75%, #D067FF 100%)
+  background-size: 400% 400%
+  border-radius: 8px
+  animation: gaming-diagonal 6s linear infinite
+
+.live-streamer__avatar-image
+  height: $avatar-small - 6px
+  width: $avatar-small - 6px
+  position: absolute
+  border-radius: 6px
+  top: 3px
+  left: 3px
+
+.live-streamer__twitter-link
+  font-weight: 400
+  font-size: 1rem

--- a/source/stylesheets/_live.css.sass
+++ b/source/stylesheets/_live.css.sass
@@ -1,0 +1,4 @@
+// .live
+
+.live__screen
+  margin-bottom: 1rem

--- a/source/stylesheets/_live.css.sass
+++ b/source/stylesheets/_live.css.sass
@@ -1,4 +1,11 @@
 // .live
 
 .live__screen
-  margin-bottom: 1rem
+
+  margin: 0 auto 2rem
+  border: 1px solid rgba(#FFF, 0.5)
+  max-width: 560px
+
+  iframe
+    +mq
+      width: 100%

--- a/source/stylesheets/site.css.sass
+++ b/source/stylesheets/site.css.sass
@@ -10,6 +10,7 @@
 @import 'bg.css.sass'
 @import 'hero.css.sass'
 @import 'live-streamer.css.sass'
+@import 'live.css.sass'
 @import 'schedule.css.sass'
 @import 'sponsor.css.sass'
 @import 'team.css.sass'

--- a/source/stylesheets/site.css.sass
+++ b/source/stylesheets/site.css.sass
@@ -9,6 +9,7 @@
 @import 'keyframes.css.sass'
 @import 'bg.css.sass'
 @import 'hero.css.sass'
+@import 'live-streamer.css.sass'
 @import 'schedule.css.sass'
 @import 'sponsor.css.sass'
 @import 'team.css.sass'


### PR DESCRIPTION
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/341101/236812024-184fc979-8267-4305-83a0-b84c39f69104.png">

当日、YouTubeの配信画面をサイトにも貼った方が良いかも？と思いその用意をしておきました
（現状は、別の動画のURLがダミーで貼ってあります）

- 当日、動画配信のURLが分かったらURLを差し替えます
- ストリーミングの許可を YouTube側でしていただく必要がありそうです :pray:  @Daihuku-Keyboard 