### PR TITLE
Keynote, Rabbit 等で使えるテンプレートやデザイン素材へのリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 - こんな感じでサイトに反映されます
   - <img width="1204" alt="image" src="https://github.com/user-attachments/assets/1091fadf-b314-4b94-a07b-ca3e693e7c31">
 
+# Keynote Template and Design Sources
+
+[Keynote, Rabbit 等のプレゼンで利用できるテンプレートやデザイン素材はこちら](https://esa-pages.io/p/sharing/3/posts/12845/3fd6e6b704ad3c8b82d1.html)
 
 # ローカル確認方法 (任意)
 

--- a/data/year_2024/general.yml
+++ b/data/year_2024/general.yml
@@ -34,5 +34,5 @@ call_for_lt:
   url: https://docs.google.com/forms/d/e/1FAIpQLSd5RJ3m8CrmXaf66j2aPI48JSZBV58TRSZ9UZtQfw8gpoGdBg/viewform
 license: This work by KeebKaigi Team is licensed under a Creative Commons Attribution 4.0 Unported License.
 design_sources:
-  text: Keynotes, Rabbit用テンプレート・デザイン素材
+  text: Keynote, Rabbit用テンプレート・デザイン素材
   url: https://esa-pages.io/p/sharing/3/posts/12845/3fd6e6b704ad3c8b82d1.html

--- a/data/year_2024/general.yml
+++ b/data/year_2024/general.yml
@@ -33,3 +33,6 @@ call_for_lt:
     いわゆる「ライトニングトーク」形式で、キーボードにかける思いを5分間で語ってくれるトークを募集しています。
   url: https://docs.google.com/forms/d/e/1FAIpQLSd5RJ3m8CrmXaf66j2aPI48JSZBV58TRSZ9UZtQfw8gpoGdBg/viewform
 license: This work by KeebKaigi Team is licensed under a Creative Commons Attribution 4.0 Unported License.
+design_sources:
+  text: Keynotes, Rabbit用テンプレート・デザイン素材
+  url: https://esa-pages.io/p/sharing/3/posts/12845/3fd6e6b704ad3c8b82d1.html

--- a/source/partials/2024/_footer.html.haml
+++ b/source/partials/2024/_footer.html.haml
@@ -20,5 +20,10 @@
                   = link_to "@#{member}",
                     "https://twitter.com/#{member}",
                     target: '_blank'
+        .footer__design-sources
+          = link_to d.general.design_sources.url,
+            target: '_blank' do
+            %i.fa-solid.fa-caret-right
+            = d.general.design_sources.text
     .footer__license
       = d.general.license

--- a/source/stylesheets/2024/_footer.css.sass
+++ b/source/stylesheets/2024/_footer.css.sass
@@ -140,3 +140,10 @@ $footer-logo-size: 16rem
 
   +mq
     margin: 1rem 0 0
+
+.footer__design-sources
+  font-size: 0.7rem
+  font-weight: normal
+  text-align: left
+  margin-top: 1rem
+  font-family: 'Zen Kaku Gothic New', sans-serif


### PR DESCRIPTION
Keynote, Rabbit 等で使えるテンプレートやデザイン素材をこちらのページにまとめました。
よかったらライセンスの範囲内で自由にご利用ください。

https://esa-pages.io/p/sharing/3/posts/12845/3fd6e6b704ad3c8b82d1.html

<img width="1378" alt="image" src="https://github.com/user-attachments/assets/0b58efc4-5373-4ad6-a32f-da589d32858d">

サイトのfooterからもダウンロードできます